### PR TITLE
Updated Stackato Sandbox URL. Stackato only accepts requests via HTTPS.

### DIFF
--- a/config/configatron/defaults.rb
+++ b/config/configatron/defaults.rb
@@ -16,7 +16,7 @@ configatron.available_targets << ["AppFog (Joyent service)", "http://api.joyent.
 configatron.available_targets << ["AppFog (Rackspace service)", "http://api.rackspace.af.cm"]
 configatron.available_targets << ["HP Cloud Services", "http://api.cloudfoundry.hpcloud.com/"]
 configatron.available_targets << ["Iron Foundry", "http://api.gofoundry.net"]
-configatron.available_targets << ["Stackato Sandbox", "http://api.sandbox.activestate.com"]
+configatron.available_targets << ["Stackato Sandbox", "https://api.stacka.to"]
 configatron.available_targets << ["VMware CloudFoundry", "http://api.cloudfoundry.com"]
 configatron.available_targets << ["VMware Micro CloudFoundry", "http://api.{Domain}.cloudfoundry.me"]
 configatron.available_targets << ["Other", "{Cloud Controller URL}"]


### PR DESCRIPTION
Tested by specifying 'https://api.stacka.to' manually under "Other".
